### PR TITLE
Automatically update initial sequence number after capture

### DIFF
--- a/capture_gui.py
+++ b/capture_gui.py
@@ -658,6 +658,9 @@ class UnifiedBookTool:
         if success:
             # Set progress bar to maximum
             total_pages = int(self.pages_var.get())
+            # Update initial sequence number for next capture
+            initial_seq = int(self.initial_seq_var.get())
+            self.initial_seq_var.set(str(initial_seq + total_pages))
             self.progress_bar.config(value=total_pages)
             
     def test_coordinates(self):


### PR DESCRIPTION

This PR implements automatic updating of the initial sequence number after a successful capture session. 

**Changes:**
- Modified `on_capture_complete` method to calculate and set the next sequence number
- New sequence number = initial sequence number + number of pages captured
- Ensures subsequent captures start with the correct sequence number

**Example:**
If you capture sequences 1-100, the next capture will automatically start at 101.

**Testing:**
1. Start a capture session with initial sequence number 0
2. Capture 100 pages
3. Verify next capture starts at sequence number 100 automatically
